### PR TITLE
Join with list not args

### DIFF
--- a/scripts/hamburger.py
+++ b/scripts/hamburger.py
@@ -446,7 +446,7 @@ def main():
         # with open(output_dir+"/cluster_stats.csv", "w") as output:
         #     output.write("gene_cluster,strain,contig,start,stop,length,number_of_mandatory_genes,found_number_of_mandatory_genes,percent_of_mandatory_genes_in_query,{hmm_genes},GC_cluster,GC_genome,GCcluster/GCgenome\n".format(hmm_genes=','.join(mandatory_names)))
 
-        total_cluster_stats.append(','.join(
+        total_cluster_stats.append(','.join([
             "gene_cluster",
             "strain",
             "contig",
@@ -460,7 +460,7 @@ def main():
             "GC_cluster",
             "GC_genome",
             "GCcluster/GCgenome"
-            )
+            ])
         )
 
 


### PR DESCRIPTION
Noticed when I tried to run hamburger from the master branch that it has a minor bug in which it couldn't join some strings. When we try to run `hamburger.py`, we get:
```
Traceback (most recent call last):
  File "/opt/hamburger/scripts/hamburger.py", line 620, in <module>
    main()
  File "/opt/hamburger/scripts/hamburger.py", line 449, in main
    total_cluster_stats.append(','.join(
TypeError: str.join() takes exactly one argument (13 given)
```

Here's a quick fix.